### PR TITLE
Introducing snakemake support

### DIFF
--- a/vkd_client/__init__.py
+++ b/vkd_client/__init__.py
@@ -7,6 +7,7 @@ for more information.
 
 from .YamlProcessor import YamlProcessor
 from .Table import Table
+from . import utils 
 
 
 def setup_vkdclient():

--- a/vkd_client/templates/from_snakemake.yaml
+++ b/vkd_client/templates/from_snakemake.yaml
@@ -4,12 +4,36 @@ data:
   - name: {{ snakemake.rule }}
     queue: {{ queue }}
     priority: {{ priority }}
+    {% if snakemake.resources.millicpu is defined %}
+    cpu_request: {{ snakemake.resources.millicpu }}m
+    {% else %}
+    cpu_request: {{ snakemake.threads }}
+    {% endif %}
+    
+    {% if snakemake.resources.mem_mb is defined %}
+    memory_request: {{ snakemake.resources.mem_mb }}Mi
+    {% endif %}
+
+    {% if snakemake.resources.gpu_mb is defined %}
+    gpu_memory_request: {{ snakemake.resources.gpu_mb }}Mi
+    {% endif %}
+
+    {% if snakemake.resources.runtime is defined %}
+    active_deadline_seconds: {{ snakemake.resources.runtime }}
+    {% endif %}
+    
 
     script: /sandbox/snakemake_script.sh
     sandbox:
       snakemake_script.sh: |
 {{ jobscript | indent(12, True) }}
 
+    {% if nfs_volumes | length %}
     volumes:
       nfs:
-        - /home/private
+      {% for volume in nfs_volumes %}
+        - {{ volume }} 
+      {% endfor %}
+    {% endif %}
+    
+        

--- a/vkd_client/templates/from_snakemake.yaml
+++ b/vkd_client/templates/from_snakemake.yaml
@@ -1,0 +1,15 @@
+method: POST
+resource: bunshinjobs
+data:
+  - name: {{ snakemake.rule }}
+    queue: {{ queue }}
+    priority: {{ priority }}
+
+    script: /sandbox/snakemake_script.sh
+    sandbox:
+      snakemake_script.sh: |
+{{ jobscript | indent(12, True) }}
+
+    volumes:
+      nfs:
+        - /home/private

--- a/vkd_client/templates/kill.yaml
+++ b/vkd_client/templates/kill.yaml
@@ -1,0 +1,6 @@
+method: DELETE
+resource: jobs
+data:
+  {% for name in jobnames %}
+  - name: {{ name }}
+  {% endfor %}

--- a/vkd_client/utils.py
+++ b/vkd_client/utils.py
@@ -1,0 +1,36 @@
+from vkd_client import YamlProcessor
+import os 
+import jinja2 
+import logging
+import json, re
+
+
+def process_form_template(template: str, **kwargs):
+    """
+    Simple utility function to process a YAML template and submit it.
+    """
+    processor = YamlProcessor()
+    logging.info(f"Processing template {template}, setting variables: [{', '.join(kwargs.keys())}]")
+    with open(os.path.join(os.path.dirname(__file__), 'templates', f'{template}.yaml')) as template_file:
+        template = jinja2.Environment().from_string(template_file.read())
+    return processor.process(template.render(**kwargs))
+
+
+
+def get_snakemake_job_properties(filepath: str):
+    """
+    Parse a Snakemake script file and return the dictionary of the job properties.
+    """
+    with open(filepath) as jobscript_file:
+        groups = re.findall(
+            "# properties = ([^\n]+)\n", 
+            [line for line in jobscript_file if line.startswith("# properties")][0]
+            )
+
+        if len(groups) == 0:
+            raise IOError("Cannot parse Snakemake script file. Properties not found.")
+        if len(groups) > 1:
+            raise IOError("Invalid Snakemake script. Too many definition for properties.")
+
+        return json.loads(groups[0])
+


### PR DESCRIPTION
Added a simple execution script to map snakemake to vkd calls. 

Requires snakemake 8+ and `snakemake-executor-plugin-cluster-sync` to run. 

A possible profile looks like:
```yaml
executor: cluster-sync
cluster-sync-submit-cmd: "vkd from-snakemake --queue lamarr"
use-apptainer: false
apptainer-args: " --bind /home --bind /cvmfs "
jobs: 8
```
